### PR TITLE
Rename quickSort.py to quickSort_2.py

### DIFF
--- a/quickSort_2.py
+++ b/quickSort_2.py
@@ -1,0 +1,19 @@
+def quickSort(x):
+    if len(x) == 1 or len(x) == 0:
+        return x
+    else:
+        pivot = x[0]
+        i = 0
+        for j in range(len(x)-1):
+            if x[j+1] < pivot:
+                x[j+1],x[i+1] = x[i+1], x[j+1]
+                i += 1
+        x[0],x[i] = x[i],x[0]
+        first_part = quickSort(x[:i])
+        second_part = quickSort(x[i+1:])
+        first_part.append(x[i])
+        return first_part + second_part
+        
+alist = [54,26,93,17,77,31,44,55,20]
+quickSort(alist)
+print(alist)


### PR DESCRIPTION
Was getting an error for some reason. Seems to run fine as this

def quicksort(x):
    if len(x) == 1 or len(x) == 0:
        return x
    else:
        pivot = x[0]
        i = 0
        for j in range(len(x)-1):
            if x[j+1] < pivot:
                x[j+1],x[i+1] = x[i+1], x[j+1]
                i += 1
        x[0],x[i] = x[i],x[0]
        first_part = quicksort(x[:i])
        second_part = quicksort(x[i+1:])
        first_part.append(x[i])
        return first_part + second_part
        
alist = [54,26,93,17,77,31,44,55,20]
quicksort(alist)
print(alist)